### PR TITLE
Host fields for services, virtual users, mailman

### DIFF
--- a/docs/debian-conf.d/main/00_mailman
+++ b/docs/debian-conf.d/main/00_mailman
@@ -1,0 +1,14 @@
+# Home dir for your Mailman installation -- aka Mailman's prefix
+# directory.
+MAILMAN_HOME=/var/lib/mailman
+MAILMAN_WRAP=MAILMAN_HOME/mail/mailman
+
+# User and group for Mailman, should match your --with-mail-gid
+# switch to Mailman's configure script.
+MAILMAN_USER=list
+MAILMAN_GROUP=daemon
+#MY_IP=x.x.x.x
+
+MM_DOMAINS = SELECT DISTINCT domain FROM domains WHERE type = 'local' AND enabled = '1' AND domain LIKE 'lists.%' AND domain = '${quote_mysql:$domain}' AND host_smtp = 'mail'
+domainlist mm_domains=${lookup mysql{MM_DOMAINS}}
+MAILMAN_LISTCHK=MAILMAN_HOME/lists/${lc::$local_part}/config.pck

--- a/docs/debian-conf.d/main/00_vexim_listmacrosdefs
+++ b/docs/debian-conf.d/main/00_vexim_listmacrosdefs
@@ -9,9 +9,9 @@
 hide mysql_servers = localhost::(/var/run/mysqld/mysqld.sock)/vexim/vexim/CHANGE
 
 # domains
-VEXIM_VIRTUAL_DOMAINS = SELECT DISTINCT domain FROM domains WHERE type = 'local' AND enabled = '1' AND domain = '${quote_mysql:$domain}'
-VEXIM_RELAY_DOMAINS = SELECT DISTINCT domain FROM domains WHERE type = 'relay'  AND domain = '${quote_mysql:$domain}'
-VEXIM_ALIAS_DOMAINS = SELECT DISTINCT alias FROM domainalias WHERE alias = '${quote_mysql:$domain}'
+VEXIM_VIRTUAL_DOMAINS = SELECT DISTINCT domain FROM domains WHERE type = 'local' AND enabled = '1' AND domain = '${quote_mysql:$domain}' AND host_smtp = 'mail'
+VEXIM_RELAY_DOMAINS = SELECT DISTINCT domain FROM domains WHERE type = 'relay'  AND domain = '${quote_mysql:$domain}' AND host_smtp = 'mail'
+VEXIM_ALIAS_DOMAINS = SELECT DISTINCT alias FROM domainalias WHERE alias = '${quote_mysql:$domain}' AND host_smtp = 'mail'
 
 # domains and relay networks
 MAIN_LOCAL_DOMAINS = MAIN_LOCAL_DOMAINS : ${lookup mysql{VEXIM_VIRTUAL_DOMAINS}} : ${lookup mysql{VEXIM_ALIAS_DOMAINS}}

--- a/setup/mysql.sql
+++ b/setup/mysql.sql
@@ -12,24 +12,27 @@ DROP TABLE IF EXISTS `vexim`.`domains`;
 CREATE TABLE IF NOT EXISTS `vexim`.`domains`
 (
     domain_id      mediumint(8)  unsigned  NOT NULL  auto_increment,
-	domain           varchar(255)            NOT NULL  default '',
-	maildir          varchar(4096)           NOT NULL  default '',
-	uid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
-	gid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
-	max_accounts     int(10)       unsigned  NOT NULL  default '0', 
-	quotas           int(10)       unsigned  NOT NULL  default '0',
-	type             varchar(5)                        default NULL,
-	avscan           bool                    NOT NULL  default '0',
-	blocklists       bool                    NOT NULL  default '0',
-	enabled          bool                    NOT NULL  default '1',
-	mailinglists     bool                    NOT NULL  default '0',
-	maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
-	pipe             bool                    NOT NULL  default '0',
-	spamassassin     bool                    NOT NULL  default '0',
-	sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
-	sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
-	PRIMARY KEY (domain_id),
-	UNIQUE KEY domain (domain)
+    domain           varchar(255)            NOT NULL  default '',
+    maildir          varchar(4096)           NOT NULL  default '',
+    uid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
+    gid              smallint(5)   unsigned  NOT NULL  default 'CHANGE',
+    max_accounts     int(10)       unsigned  NOT NULL  default '0', 
+    quotas           int(10)       unsigned  NOT NULL  default '0',
+    type             varchar(5)                        default NULL,
+    avscan           bool                    NOT NULL  default '0',
+    blocklists       bool                    NOT NULL  default '0',
+    enabled          bool                    NOT NULL  default '1',
+    mailinglists     bool                    NOT NULL  default '0',
+    maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
+    pipe             bool                    NOT NULL  default '0',
+    spamassassin     bool                    NOT NULL  default '0',
+    sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
+    sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
+    host_smtp        varchar(255)                      default 'mail',
+    host_imap        varchar(255)                      default 'mail',
+    host_pop         varchar(255)                      default 'mail',
+    PRIMARY KEY (domain_id),
+    UNIQUE KEY domain (domain)
 );
 
 --
@@ -39,40 +42,40 @@ DROP TABLE IF EXISTS `vexim`.`users`;
 CREATE TABLE IF NOT EXISTS `vexim`.`users` 
 (
     user_id          int(10)       unsigned  NOT NULL  auto_increment,
-	domain_id        mediumint(8)  unsigned  NOT NULL,
-	localpart        varchar(64)             NOT NULL  default '',
-	username         varchar(255)            NOT NULL  default '',
-	crypt            varchar(255)                       default NULL,
-	uid              smallint(5)   unsigned  NOT NULL  default '65534',
-	gid              smallint(5)   unsigned  NOT NULL  default '65534',
-	smtp             varchar(4096)                     default NULL,
-	pop              varchar(4096)                     default NULL,
-	type             enum('local', 'alias', 
-                          'catch', 'fail', 
-                          'piped', 'admin', 
-                          'site')            NOT NULL  default 'local',
-	admin            bool                    NOT NULL  default '0',
-	on_avscan        bool                    NOT NULL  default '0',
-	on_blocklist     bool                    NOT NULL  default '0',
-	on_forward       bool                    NOT NULL  default '0',
-	on_piped         bool                    NOT NULL  default '0',
-	on_spamassassin  bool                    NOT NULL  default '0',
-	on_vacation      bool                    NOT NULL  default '0',
-	spam_drop        bool                    NOT NULL  default '0',
-	enabled          bool                    NOT NULL  default '1',
-	flags            varchar(16)                       default NULL,
-	forward          varchar(255)                      default NULL,
+    domain_id        mediumint(8)  unsigned  NOT NULL,
+    localpart        varchar(64)             NOT NULL  default '',
+    username         varchar(255)            NOT NULL  default '',
+    crypt            varchar(255)                         default NULL,
+    uid              smallint(5)   unsigned  NOT NULL  default '65534',
+    gid              smallint(5)   unsigned  NOT NULL  default '65534',
+    smtp             varchar(4096)                     default NULL,
+    pop              varchar(4096)                     default NULL,
+    type             enum('local', 'alias', 
+                        'catch', 'fail', 
+                        'piped', 'admin',
+                        'site')              NOT NULL  default 'local',
+    admin            bool                    NOT NULL  default '0',
+    on_avscan        bool                    NOT NULL  default '0',
+    on_blocklist     bool                    NOT NULL  default '0',
+    on_forward       bool                    NOT NULL  default '0',
+    on_piped         bool                    NOT NULL  default '0',
+    on_spamassassin  bool                    NOT NULL  default '0',
+    on_vacation      bool                    NOT NULL  default '0',
+    spam_drop        bool                    NOT NULL  default '0',
+    enabled          bool                    NOT NULL  default '1',
+    flags            varchar(16)                       default NULL,
+    forward          varchar(255)                      default NULL,
     unseen           bool                              default '0',
-	maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
-	quota            int(10)       unsigned  NOT NULL  default '0',
-	realname         varchar(255)                      default NULL,
-	sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
-	sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
-	tagline          varchar(255)                      default NULL,
-	vacation         varchar(1024)                      default NULL,
-	PRIMARY KEY (user_id),
-	UNIQUE KEY username (localpart, domain_id),
-	KEY local (localpart)
+    maxmsgsize       mediumint(8)  unsigned  NOT NULL  default '0',
+    quota            int(10)       unsigned  NOT NULL  default '0',
+    realname         varchar(255)                      default NULL,
+    sa_tag           smallint(5)   unsigned  NOT NULL  default '0',
+    sa_refuse        smallint(5)   unsigned  NOT NULL  default '0',
+    tagline          varchar(255)                      default NULL,
+    vacation         varchar(1024)                     default NULL,
+    PRIMARY KEY (user_id),
+    UNIQUE KEY username (localpart, domain_id),
+    KEY local (localpart)
 );
 
 --
@@ -82,12 +85,12 @@ DROP TABLE IF EXISTS `vexim`.`blocklists`;
 CREATE TABLE IF NOT EXISTS `vexim`.`blocklists`
 (
     block_id         int(10)       unsigned  NOT NULL  auto_increment,
-  	domain_id        mediumint(8)  unsigned  NOT NULL,
-	user_id          int(10)       unsigned            default NULL,
-	blockhdr         varchar(192)            NOT NULL  default '',
-	blockval         varchar(255)            NOT NULL  default '',
-	color            varchar(8)              NOT NULL  default '',
-	PRIMARY KEY (block_id)
+    domain_id        mediumint(8)  unsigned  NOT NULL,
+    user_id          int(10)       unsigned            default NULL,
+    blockhdr         varchar(192)            NOT NULL  default '',
+    blockval             archar(255)            NOT NULL  default '',
+    color            varchar(8)              NOT NULL  default '',
+    PRIMARY KEY (block_id)
 );
 
 
@@ -97,7 +100,10 @@ CREATE TABLE IF NOT EXISTS `vexim`.`blocklists`
 CREATE TABLE IF NOT EXISTS `vexim`.`domainalias` 
 (
     domain_id        mediumint(8)  unsigned  NOT NULL,
-	alias varchar(255)
+    alias varchar(255),
+    host_smtp        varchar(255)                      default 'mail',
+    host_imap        varchar(255)                      default 'mail',
+    host_pop         varchar(255)                      default 'mail'
 );
 
 --

--- a/setup/pgsql.sql
+++ b/setup/pgsql.sql
@@ -15,7 +15,10 @@ CREATE TABLE domains (domain_id SERIAL PRIMARY KEY,
 	quotas int NOT NULL default '0' CHECK(quotas > -1),
 	maxmsgsize int NOT NULL default '0' CHECK(maxmsgsize > -1),
 	sa_tag int NOT NULL default '0' CHECK(sa_tag > -1),
-	sa_refuse int NOT NULL default '0' CHECK(sa_refuse > -1));
+	sa_refuse int NOT NULL default '0' CHECK(sa_refuse > -1)),
+	host_smtp varchar(255) default 'mail',
+	host_imap varchar(255) default 'mail',
+	host_pop varchar(255) default 'mail';
 CREATE TABLE users (user_id SERIAL PRIMARY KEY,
 	domain_id int NOT NULL,
 	localpart varchar(64) NOT NULL,
@@ -54,7 +57,10 @@ CREATE TABLE blocklists (block_id SERIAL PRIMARY KEY,
 	color varchar(8) NOT NULL default '');
 CREATE INDEX blocklists_user_id_key ON blocklists (user_id);
 CREATE TABLE domainalias (domain_id int NOT NULL,
-        alias varchar(255));
+        alias varchar(255)),
+	host_smtp varchar(255) default 'mail',
+	host_imap varchar(255) default 'mail',
+	host_pop varchar(255) default 'mail';
 CREATE TABLE groups (
         id                  SERIAL PRIMARY KEY,
         domain_id           int CHECK(domain_id > -1),


### PR DESCRIPTION
The server/service could retrieve a 'host' field from the database to decide if the domain belongs to it.
I suggest to have different 'host' fields for different services: smtp, imap, pop

Dovecot has such a feature for its proxy: http://wiki2.dovecot.org/PasswordDatabase/ExtraFields/Proxy

Add exim config file for mailman